### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,7 +52,7 @@ class KeyVaultSettings:
                 self._secrets[secret_name] = secret.value
             return self._secrets[secret_name]
         except Exception as e:
-            logger.error(f"Failed to get secret {secret_name}: {str(e)}")
+            logger.error("Failed to get secret. An error occurred.")
             raise
 
 @lru_cache()


### PR DESCRIPTION
Potential fix for [https://github.com/passadis/ai-foundry-mutlimodels/security/code-scanning/1](https://github.com/passadis/ai-foundry-mutlimodels/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information directly. Instead of logging the `secret_name`, we can log a generic message that does not include the sensitive data. This way, we still capture the occurrence of an error without exposing sensitive information.

We will modify the error logging on line 55 to remove the `secret_name` from the log message. We will also ensure that the exception message `str(e)` does not contain sensitive information by logging a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
