### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -58,7 +58,7 @@ class KeyVaultSettings:
                 self._secrets[secret_name] = secret.value
             return self._secrets[secret_name]
         except Exception as e:
-            logger.error(f"Failed to get secret {secret_name}: {str(e)}")
+            logger.error(f"Failed to retrieve secret from KeyVault: {str(e)}")
             raise
 
 @lru_cache()


### PR DESCRIPTION
Potential fix for [https://github.com/passadis/ai-foundry-multimodels/security/code-scanning/1](https://github.com/passadis/ai-foundry-multimodels/security/code-scanning/1)

In general, to fix clear-text logging of sensitive information, remove sensitive values (or their identifiers) from log messages, or replace them with generic descriptions or redacted tokens. Where diagnostic context is required, log only non-sensitive metadata (such as an internal error code) that cannot be used to infer secrets.

For this code, the best minimal fix is to change the error logging in `get_secret` so that it no longer includes `secret_name` directly. Instead, we can log a generic message like `"Failed to retrieve secret from KeyVault"` and optionally include a safe error detail (for example, the exception type) that does not reveal secret names or values. This keeps existing behavior (raising the exception, caching logic, etc.) intact while eliminating leakage of potentially sensitive identifiers. Concretely, in `backend/app/config.py` we will replace line 61 with a sanitized log message that omits `secret_name`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
